### PR TITLE
Prevent stacktrace when account_balance_market_value_node doesn't contain opering_currency

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -156,8 +156,8 @@ class FavaClassyPortfolio(FavaExtensionBase):  # pragma: no cover
             get_market_value,
             g.ledger.price_map,
             datetime.date.today())
-        account_balance_market_value = account_balance_market_value_node[
-            self.operating_currency]
+        account_balance_market_value = account_balance_market_value_node.get(
+            self.operating_currency, ZERO)
 
         # Calculate unrealized gain/loss
         # (follow beancount convention that negative values are income)


### PR DESCRIPTION
I have some account(s)? that were triggering a stacktrace during processing due to a KeyError.

I am not 100% sure this addresses the root-cause, but with this fix, the report is generated properly.
